### PR TITLE
Fix wording on "on behalf" message

### DIFF
--- a/app/views/find-your-address.html
+++ b/app/views/find-your-address.html
@@ -19,7 +19,7 @@ Find your address
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <div class="govuk-inset-text beis-inset-info">
-        If you’re applying on behalf of a family member, answer these questions with their details rather than your own.
+        If you’re applying on behalf of someone else, answer these questions with their details rather than your own.
       </div>
       {% call govukFieldset({
         legend: {


### PR DESCRIPTION
I realised I'd left in the draft "a family member" where "someone else" is probably more appropriate until we test further.