### PR TITLE
Remove the AFP question from the flow

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -157,6 +157,18 @@ router.get(['/fuel-check'], (req, res) => {
   }
 })
 
+router.get(['/ebss-check'], (req, res) => {
+  switch (req.session.data['received-main-ebss']) {
+    case 'yes':
+      res.redirect('/ineligible-for-ebss-af')
+      break
+    case 'no':
+    default:
+      res.redirect('/eligible-for-ebss-af')
+      break
+  }
+})
+
 router.get(['/afp-check'], (req, res) => {
   const receivedMainEbss = req.session.data['received-main-ebss'] === 'yes'
   const receivedAfp = req.session.data['received-main-afp'] === 'yes'

--- a/app/views/check-your-answers.html
+++ b/app/views/check-your-answers.html
@@ -18,8 +18,8 @@ Check your answers before sending your application
 
 
 {% set emailAddress %}
-{% if data['email-address'] %}
-{{ data['email-address'] }}
+{% if data['email'] %}
+{{ data['email'] }}
 {% else %}
 No email address provided
 {% endif %}
@@ -92,9 +92,9 @@ No phone number provided
           actions: {
             items: [
               {
-                href: "what-is-your-email-address",
+                href: "what-is-your-full-name",
                 text: "Change",
-                visuallyHiddenText: "email address"
+                visuallyHiddenText: "name"
               }
             ]
           }
@@ -109,9 +109,9 @@ No phone number provided
           actions: {
             items: [
               {
-                href: "what-is-your-email-address",
+                href: "what-is-your-date-of-birth",
                 text: "Change",
-                visuallyHiddenText: "email address"
+                visuallyHiddenText: "date of birth"
               }
             ]
           }
@@ -185,23 +185,6 @@ No phone number provided
             items: [
               {
                 href: "have-you-received-a-payment-ebss",
-                text: "Change",
-                visuallyHiddenText: "answer"
-              }
-            ]
-          }
-        },
-        {
-          key: {
-            text: "Have you already had the alternative fuels payment?"
-          },
-          value: {
-            html: data['received-main-afp'] | capitalize if data['received-main-afp'] else 'No'
-          },
-          actions: {
-            items: [
-              {
-                href: "have-you-received-a-payment-afp",
                 text: "Change",
                 visuallyHiddenText: "answer"
               }

--- a/app/views/eligible-for-ebss-af.html
+++ b/app/views/eligible-for-ebss-af.html
@@ -1,0 +1,31 @@
+
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+You can apply for the £400 Energy Bills Support Scheme payment
+{% endblock %}
+
+{% from "./alphaPhase.html" import alphaPhase %}
+{% block beforeContent %}
+{{ alphaPhase() }}
+{{ govukBackLink({
+  text: "Back",
+  href: "have-you-received-a-payment-ebss"
+}) }}
+{% endblock %}
+
+
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">You can apply for the £400 Energy Bills Support Scheme payment</h1>
+    <p class="govuk-body">We need to ask you additional questions so we can check you are eligible.</p>
+    {{ govukButton({
+      text: "Continue",
+      href: "what-is-your-full-name"
+    }) }}
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/have-you-received-a-payment-ebss.html
+++ b/app/views/have-you-received-a-payment-ebss.html
@@ -44,7 +44,7 @@ Have you received a payment from the Energy Bills Support Scheme already?
 
 
 {% block content %}
-<form action="do-you-use-one-of-these-fuels">
+<form action="ebss-check">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       {{ govukRadios({

--- a/app/views/ineligible-for-ebss-af.html
+++ b/app/views/ineligible-for-ebss-af.html
@@ -1,0 +1,29 @@
+
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+You can’t apply for energy bills support
+{% endblock %}
+
+{% from "./alphaPhase.html" import alphaPhase %}
+{% block beforeContent %}
+{{ alphaPhase() }}
+{{ govukBackLink({
+  text: "Back",
+  href: "have-you-received-a-payment-ebss"
+}) }}
+{% endblock %}
+
+
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">You do not need to apply for energy bills support from these schemes</h1>
+    <p class="govuk-body">You told us you are already getting the £400 Energy Bills Support Scheme discount automatically from your energy supplier.</p>
+    <h2 class="govuk-heading-m">Find other support</h2>
+    <p class="govuk-body">Check what other help you could get with your energy bills from the government's <a href="https://helpforhouseholds.campaign.gov.uk/help-with-your-bills/" class="govuk-link">Help for Households</a></p>
+    <p class="govuk-body">Find out if you can get support from your local council from the <a href="https://www.gov.uk/find-local-council" class="govuk-link">Household Support Fund.</a></p>
+  </div>
+</div>
+{% endblock %}

--- a/app/views/what-is-your-full-name.html
+++ b/app/views/what-is-your-full-name.html
@@ -22,7 +22,7 @@ What is your full name?
 {{ alphaPhase() }}
   {{ govukBackLink({
     text: "Back",
-    href: backLink
+    href: 'eligible-for-ebss-af'
   }) }}
 {% endblock %}
 


### PR DESCRIPTION
I've not binned off the pages altogether, so we can always drop this back in if our policy changes or if we need it for NI. @eleanorgrigson you may just want to review the eligibility pages on this.