### PR TITLE
Always require POA from care home residents

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -227,14 +227,11 @@ router.get(['/contact-check'], (req, res) => {
 })
 
 router.get(['/council-tax-check'], (req, res) => {
-  switch (req.session.data['are-you-registered-for-council-tax']) {
-    case 'no':
-    case 'no-council-tax':
-      res.redirect('/upload-proof-of-address')
-      break
-    default:
-      res.redirect('/what-is-your-full-name')
-      break
+  const proofRequired = req.session.data['describe-where-you-live'] === 'care-home' || req.session.data['are-you-registered-for-council-tax'] === 'no'
+  if (proofRequired) {
+    res.redirect('/upload-proof-of-address')
+  } else {
+    res.redirect('/what-is-your-full-name')
   }
 })
 


### PR DESCRIPTION
@eleanorgrigson Care home residents will always reach the proof of address page which needs the content update here: [`upload-proof-of-address`](https://github.com/ebss-alpha/alpha-prototype/blob/care-home-branching/app/views/upload-proof-of-address.html)