### PR TITLE
Add cookies banner

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -11,15 +11,24 @@ router.get(['/'], (req, res) => {
 })
 
 router.get(['/start'], (req, res) => {
-  req.session.data = {}
+  req.session.data = {
+    cookies: req.session.data.cookies
+  }
   res.render('start.html')
 })
 
 router.get(['/ni'], (req, res) => {
   req.session.data = {
+    cookies: req.session.data.cookies,
     locale: 'ni'
   }
   res.render('ni.html')
+})
+
+router.get(['/cookie-choice'], (req, res) => {
+  const cookieChoice = req.query.choice === 'accept'
+  req.session.data.cookies = cookieChoice
+  res.redirect(req.headers.referer)
 })
 
 router.get(['/location-check'], (req, res) => {

--- a/app/views/cookies.html
+++ b/app/views/cookies.html
@@ -43,6 +43,33 @@ Cookies
                 </tr>
             </tbody>
         </table>
+        <form action="cookie-choice">
+            {{ govukRadios({
+            name: "choice",
+            classes: 'govuk-radios--inline',
+            fieldset: {
+                legend: {
+                    text: "Do you want to accept analytics cookies?",
+                    classes: "govuk-fieldset__legend--s"
+                }
+            },
+            items: [
+                {
+                    value: "accept",
+                    text: "Yes",
+                    checked: data.cookies == true
+                },
+                {
+                    value: "reject",
+                    text: "No",
+                    checked: data.cookies == false
+                }
+            ]
+            }) }}
+            {{ govukButton({
+            text: "Save cookie settings"
+            }) }}
+        </form>
     </div>
 </div>
 {% endblock %}

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -46,7 +46,42 @@
 {% else %}
 {% set headerLink = '/start' %}
 {% endif %}
-
+{% set html %}
+<p class="govuk-body">We use some essential cookies to make this service work.</p>
+<p class="govuk-body">We’d also like to use analytics cookies so we can understand how you use the service and make
+  improvements.</p>
+{% endset %}
+{% set bannerTitle %}Cookies on {{ serviceName }}{% endset %}
+{% if data.cookies == undefined %}
+{{ govukCookieBanner({
+  ariaLabel: bannerTitle,
+  messages: [
+    {
+    headingText: bannerTitle,
+    html: html,
+    actions: [
+      {
+        text: "Accept analytics cookies",
+        type: "button",
+        name: "cookies",
+        href: "cookie-choice?choice=accept"
+      },
+      {
+        text: "Reject analytics cookies",
+        type: "button",
+        name: "cookies",
+        href: "cookie-choice?choice=reject"
+      },
+      {
+        text: "View cookies",
+        href: "cookies"
+      }
+    ]
+    }
+  ]
+})
+}}
+{% endif %}
  {# Set serviceName in config.js. #}
  {{ govukHeader({
    homepageUrl: "/",


### PR DESCRIPTION
As we're considering introducing Google Analytics to our service, we'll need to get explicit consent from the user in order to use these non-essential cookies. The UI pattern for this is standardised in the GOVUK design system, so we'll use that same approach:
![localhost_3000_start](https://user-images.githubusercontent.com/2814421/212679798-c9f8bac2-d3ef-436e-ac48-4564a38da68a.png)
![localhost_3000_cookies](https://user-images.githubusercontent.com/2814421/212679809-9facbb56-2383-4f4c-8bf9-6329ad84950e.png)
